### PR TITLE
fix: extend scripts source set from main classpath for IntelliJ completion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,10 @@ val scriptsSourceSet =
   }
 tasks.named("compileScriptsGroovy") { enabled = false }
 
+dependencies {
+  add(scriptsSourceSet.compileOnlyConfigurationName, localGroovy())
+}
+
 codenarc {
   toolVersion = libs.versions.codenarc.get()
   configFile = file("config/codenarc/codenarc-src.xml")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.api.plugins.quality.CodeNarc
 import org.gradle.api.tasks.compile.GroovyCompile
@@ -26,8 +27,10 @@ val scriptsSourceSet =
   }
 tasks.named("compileScriptsGroovy") { enabled = false }
 
-dependencies {
-  add(scriptsSourceSet.compileOnlyConfigurationName, localGroovy())
+val mainCompileOnly = configurations.named(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
+val mainImplementation = configurations.named(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)
+configurations.named(scriptsSourceSet.compileOnlyConfigurationName) {
+  extendsFrom(mainCompileOnly, mainImplementation)
 }
 
 codenarc {


### PR DESCRIPTION
## Summary

- `scripts/export-jenkins-catalog.groovy` had no dependencies on its source set, so IntelliJ reported a missing Groovy SDK and provided no Jenkins API completion.
- Extends `scriptsCompileOnly` from the main source set's `compileOnly` and `implementation` configurations using `JavaPlugin` constants and the provider-based `extendsFrom` overload — no magic strings, no `.get()` on Providers.
- Compilation for the source set remains disabled (`compileScriptsGroovy` is still `enabled = false`); this is purely for IDE resolution.

## Test plan

- [x] Gradle sync in IntelliJ — no "Groovy SDK not configured" warning; Jenkins core and plugin APIs resolve in `scripts/export-jenkins-catalog.groovy`
- [ ] `./gradlew check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)