### PR TITLE
docs: pre-release cleanup — fix template setup steps and skip CI for docs-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE.txt'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE.txt'
+      - '.gitignore'
   workflow_dispatch:
     inputs:
       plugin-ref:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ class MySpec : JenkinsFunSpec({
 
 1. Replace `src/com/mkobit/libraryexample/` with your package structure and update `vars/`.
 2. Set `rootProject.name` in `settings.gradle.kts` to your Jenkins library name.
-3. Swap the Jenkins BOM version in `gradle/libs.versions.toml` for your target LTS line.
+3. To target a different Jenkins LTS line, set `sharedLibrary { jenkins { version = "..." } }` in `build.gradle.kts` (default: `2.479.1`).
 4. Pin to a released plugin version on the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.mkobit.jenkins.pipelines.shared-library).
 5. Remove the `// TEMPLATE FORK` lines in `settings.gradle.kts` and drop `compatibility.yml`.

--- a/README.md
+++ b/README.md
@@ -69,4 +69,6 @@ class MySpec : JenkinsFunSpec({
 2. Set `rootProject.name` in `settings.gradle.kts` to your Jenkins library name.
 3. To target a different Jenkins LTS line, set `sharedLibrary { jenkins { version = "..." } }` in `build.gradle.kts` (default: `2.479.1`).
 4. Pin to a released plugin version on the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.mkobit.jenkins.pipelines.shared-library).
-5. Remove the `// TEMPLATE FORK` lines in `settings.gradle.kts` and drop `compatibility.yml`.
+5. Drop the composite-build wiring used during plugin development:
+   - Remove `includeBuild("../jenkins-pipeline-shared-libraries-gradle-plugin")` from `settings.gradle.kts`.
+   - Remove the `// TEMPLATE FORK` blocks in `.github/workflows/build.yml`.


### PR DESCRIPTION
## Summary

- Adds `paths-ignore` for `*.md`, `LICENSE.txt`, and `.gitignore` to `build.yml` so the composite build no longer runs for documentation-only changes.
- Fixes README step 3 to describe how the Jenkins LTS line is actually controlled (`sharedLibrary { jenkins { version } }` in `build.gradle.kts`, not editing `gradle/libs.versions.toml`).
- Fixes README step 5 to point at the real composite-build hooks: the `includeBuild(...)` in `settings.gradle.kts` and the `// TEMPLATE FORK` blocks in `.github/workflows/build.yml`. The previous text referenced markers in `settings.gradle.kts` that do not exist and a `compatibility.yml` that was removed in #23.

## Why

This repo becomes a GitHub template at M6 ([context](https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin)). The template-setup section in the README must accurately describe what consumers do after forking. Two of the five steps were wrong on details and would have been actively misleading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)