### PR TITLE
ci: split build into standard and composite jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,5 @@
 name: Build
 
-# Builds the example against the plugin source via composite build.
-# This is the development workflow — it tests the example against plugin source directly.
-#
-# TEMPLATE FORK: if you only consume the published plugin from the Gradle Plugin Portal,
-# remove the "path: example", plugin ref resolution, and plugin checkout steps, and drop
-# the working-directory override on the Build step.
-
 on:
   push:
     branches:
@@ -23,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       plugin-ref:
-        description: "Plugin branch/tag to test against (default: main)"
+        description: "Plugin branch/tag for composite build job (default: main)"
         default: main
 
 permissions: {}
@@ -42,34 +35,37 @@ jobs:
     env:
       DEVELOCITY_PUBLISH: "1"
     steps:
-      # TEMPLATE FORK: remove `path: example` when the plugin checkout steps below are removed
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          path: example
-
-      # TEMPLATE FORK: remove these two steps (plugin ref resolution and plugin source checkout)
-      - name: Resolve plugin ref
-        id: plugin-ref
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "ref=${{ inputs.plugin-ref }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=main" >> "$GITHUB_OUTPUT"
-          fi
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          repository: mkobit/jenkins-pipeline-shared-libraries-gradle-plugin
-          ref: ${{ steps.plugin-ref.outputs.ref }}
-          path: jenkins-pipeline-shared-libraries-gradle-plugin
-      # TEMPLATE FORK: end of steps to remove
-
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           java-version: 21
           distribution: temurin
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
-      # TEMPLATE FORK: remove `working-directory` when the plugin checkout steps above are removed
+      - name: Build
+        run: ./gradlew build --continue
+
+  build-composite:
+    name: Build (composite — plugin ${{ inputs.plugin-ref || 'main' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      DEVELOCITY_PUBLISH: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          path: example
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: mkobit/jenkins-pipeline-shared-libraries-gradle-plugin
+          ref: ${{ inputs.plugin-ref || 'main' }}
+          path: jenkins-pipeline-shared-libraries-gradle-plugin
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
       - name: Build
         working-directory: example
         run: ./gradlew build --continue

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 pluginManagement {
-  includeBuild("../jenkins-pipeline-shared-libraries-gradle-plugin")
+  if (file("../jenkins-pipeline-shared-libraries-gradle-plugin/settings.gradle.kts").exists()) {
+    includeBuild("../jenkins-pipeline-shared-libraries-gradle-plugin")
+  }
   repositories {
     gradlePluginPortal()
   }


### PR DESCRIPTION
## Summary

- `settings.gradle.kts`: conditionally includes the plugin sibling build only when `../jenkins-pipeline-shared-libraries-gradle-plugin/settings.gradle.kts` exists — standalone checkouts resolve from the Gradle Plugin Portal automatically, no changes needed for template consumers
- `build.yml`: two jobs:
  - **Build** — standard checkout, normal consumer path
  - **Build (composite)** — checks out both repos as siblings so the conditional fires, builds against plugin `main` (or a specific ref via `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)