### PR TITLE
feat: demonstrate peer shared library via :config-lib and :base-lib

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "enhancement"
     cooldown:
       # Gradle wrapper and test-framework bumps can land quickly; Jenkins plugin
       # dependencies managed by the BOM are in the ignore list below.
@@ -30,6 +32,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "infra"
     cooldown:
       default-days: 30
     groups:

--- a/base-lib/build.gradle.kts
+++ b/base-lib/build.gradle.kts
@@ -1,10 +1,7 @@
 plugins {
-  // Plugin already on the classpath via the root project — see config-lib/build.gradle.kts.
   id("com.mkobit.jenkins.pipelines.shared-library")
 }
 
-// :base-lib is the third level of the transitive chain. :config-lib declares this as a peer,
-// and root depends on :config-lib only — so :base-lib must reach Jenkins via source-variant
-// transitivity (sharedLibrarySourceElements extendsFrom sharedLibraryDependencies).
-sharedLibrary {
+codenarc {
+  configFile = rootProject.file("config/codenarc/codenarc-src.xml")
 }

--- a/base-lib/build.gradle.kts
+++ b/base-lib/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+  // Plugin already on the classpath via the root project — see config-lib/build.gradle.kts.
+  id("com.mkobit.jenkins.pipelines.shared-library")
+}
+
+// :base-lib is the third level of the transitive chain. :config-lib declares this as a peer,
+// and root depends on :config-lib only — so :base-lib must reach Jenkins via source-variant
+// transitivity (sharedLibrarySourceElements extendsFrom sharedLibraryDependencies).
+sharedLibrary {
+}

--- a/base-lib/vars/baseAnnounce.groovy
+++ b/base-lib/vars/baseAnnounce.groovy
@@ -1,0 +1,4 @@
+/** Demo step from :base-lib — proves :base-lib reaches Jenkins via :config-lib's transitive declaration. */
+def call(String message) {
+    echo "[base-lib] ${message}"
+}

--- a/base-lib/vars/baseAnnounce.groovy
+++ b/base-lib/vars/baseAnnounce.groovy
@@ -1,4 +1,3 @@
-/** Demo step from :base-lib — proves :base-lib reaches Jenkins via :config-lib's transitive declaration. */
 def call(String message) {
     echo "[base-lib] ${message}"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,11 @@ sharedLibrary {
     plugins(jenkinsPlugins.bundles.allPlugins)
     plugin("org.6wind.jenkins:lockable-resources:1305.v1a_3035fa_9065")
   }
+  dependencies {
+    // Peer JSL contributed by :config-lib — its classes are available on this project's
+    // compile/test classpaths, and Jenkins loads its source automatically during integrationTest.
+    sharedLibrary(project(":config-lib"))
+  }
 }
 
 tasks.named<CodeNarc>("codenarcScripts") {

--- a/config-lib/build.gradle.kts
+++ b/config-lib/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+  // No version: the plugin is already on the classpath via the root project's `alias()`
+  // application. Repeating `alias(libs.plugins.shared.library)` here would request the
+  // catalog-pinned 0.11.0 against an includeBuild-substituted plugin of "unknown version",
+  // which Gradle's plugin classpath check rejects.
+  id("com.mkobit.jenkins.pipelines.shared-library")
+}
+
+// :config-lib is a peer Jenkins shared library consumed by the root :main library via
+// `sharedLibrary(project(":config-lib"))`. Demonstrates the multi-project peer dependency
+// scenario in issue #158. No Jenkins plugins of its own — defaults apply.
+sharedLibrary {
+}

--- a/config-lib/build.gradle.kts
+++ b/config-lib/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 
 // :config-lib is a peer Jenkins shared library consumed by the root :main library via
 // `sharedLibrary(project(":config-lib"))`. Demonstrates the multi-project peer dependency
-// scenario in issue #158. No Jenkins plugins of its own — defaults apply.
+// scenario in issue #158. Declares :base-lib as its own peer so root reaches :base-lib only
+// through source-variant transitivity (sharedLibrarySourceElements extendsFrom).
 sharedLibrary {
+  dependencies {
+    sharedLibrary(project(":base-lib"))
+  }
 }

--- a/config-lib/build.gradle.kts
+++ b/config-lib/build.gradle.kts
@@ -1,15 +1,11 @@
 plugins {
-  // No version: the plugin is already on the classpath via the root project's `alias()`
-  // application. Repeating `alias(libs.plugins.shared.library)` here would request the
-  // catalog-pinned 0.11.0 against an includeBuild-substituted plugin of "unknown version",
-  // which Gradle's plugin classpath check rejects.
   id("com.mkobit.jenkins.pipelines.shared-library")
 }
 
-// :config-lib is a peer Jenkins shared library consumed by the root :main library via
-// `sharedLibrary(project(":config-lib"))`. Demonstrates the multi-project peer dependency
-// scenario in issue #158. Declares :base-lib as its own peer so root reaches :base-lib only
-// through source-variant transitivity (sharedLibrarySourceElements extendsFrom).
+codenarc {
+  configFile = rootProject.file("config/codenarc/codenarc-src.xml")
+}
+
 sharedLibrary {
   dependencies {
     sharedLibrary(project(":base-lib"))

--- a/config-lib/src/com/mkobit/libraryexample/config/SiteConfig.groovy
+++ b/config-lib/src/com/mkobit/libraryexample/config/SiteConfig.groovy
@@ -1,0 +1,19 @@
+package com.mkobit.libraryexample.config
+
+import com.cloudbees.groovy.cps.NonCPS
+
+/** Site-to-region mapping shared across multiple Jenkins shared libraries. */
+class SiteConfig implements Serializable {
+
+    @NonCPS
+    static String region(String site) {
+        switch (site) {
+            case 'us-east':
+                return 'us-east-1'
+            case 'eu-west':
+                return 'eu-west-1'
+            default:
+                return 'unknown'
+        }
+    }
+}

--- a/config-lib/src/com/mkobit/libraryexample/config/SiteConfig.groovy
+++ b/config-lib/src/com/mkobit/libraryexample/config/SiteConfig.groovy
@@ -2,7 +2,6 @@ package com.mkobit.libraryexample.config
 
 import com.cloudbees.groovy.cps.NonCPS
 
-/** Site-to-region mapping shared across multiple Jenkins shared libraries. */
 class SiteConfig implements Serializable {
 
     @NonCPS

--- a/config-lib/vars/siteRegion.groovy
+++ b/config-lib/vars/siteRegion.groovy
@@ -1,4 +1,3 @@
-/** Returns the canonical region for a logical site name (`us-east`, `eu-west`, …). */
 def call(String site) {
-    return com.mkobit.libraryexample.config.SiteConfig.region(site)
+    com.mkobit.libraryexample.config.SiteConfig.region(site)
 }

--- a/config-lib/vars/siteRegion.groovy
+++ b/config-lib/vars/siteRegion.groovy
@@ -1,3 +1,5 @@
+import com.mkobit.libraryexample.config.SiteConfig
+
 def call(String site) {
-    com.mkobit.libraryexample.config.SiteConfig.region(site)
+    SiteConfig.region(site)
 }

--- a/config-lib/vars/siteRegion.groovy
+++ b/config-lib/vars/siteRegion.groovy
@@ -1,0 +1,4 @@
+/** Returns the canonical region for a logical site name (`us-east`, `eu-west`, …). */
+def call(String site) {
+    return com.mkobit.libraryexample.config.SiteConfig.region(site)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,4 +40,5 @@ rootProject.name = "jenkins-pipeline-shared-library-example"
 
 // :config-lib is a peer Jenkins shared library — root project consumes it via
 // `sharedLibrary(project(":config-lib"))` to demonstrate the multi-library workflow (#158).
-include("config-lib")
+// :base-lib is :config-lib's own peer — reaches root only through source-variant transitivity.
+include("config-lib", "base-lib")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,7 +38,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "jenkins-pipeline-shared-library-example"
 
-// :config-lib is a peer Jenkins shared library — root project consumes it via
-// `sharedLibrary(project(":config-lib"))` to demonstrate the multi-library workflow (#158).
-// :base-lib is :config-lib's own peer — reaches root only through source-variant transitivity.
 include("config-lib", "base-lib")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,3 +37,7 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "jenkins-pipeline-shared-library-example"
+
+// :config-lib is a peer Jenkins shared library — root project consumes it via
+// `sharedLibrary(project(":config-lib"))` to demonstrate the multi-library workflow (#158).
+include("config-lib")

--- a/test/integration-junit/java/com/mkobit/libraryexample/IntegrationTest.java
+++ b/test/integration-junit/java/com/mkobit/libraryexample/IntegrationTest.java
@@ -81,6 +81,18 @@ class IntegrationTest {
   }
 
   @Test
+  void baseAnnounceStepFromTransitivelyLoadedPeerLibraryWorks(JenkinsRule rule) throws Exception {
+    // Root declares only :config-lib. :config-lib in turn declares :base-lib as its own peer.
+    // The :base-lib source directory reaches Jenkins only through source-variant transitivity
+    // (sharedLibrarySourceElements extendsFrom sharedLibraryDependencies on the producer).
+    var job = rule.createProject(WorkflowJob.class, "junit-transitive-peer");
+    job.setDefinition(new CpsFlowDefinition("baseAnnounce('hello from root')", true));
+
+    WorkflowRun run = rule.buildAndAssertSuccess(job);
+    rule.assertLogContains("[base-lib] hello from root", run);
+  }
+
+  @Test
   void siteConfigClassFromPeerLibrarySrcAccessibleFromPipeline(JenkinsRule rule) throws Exception {
     var job = rule.createProject(WorkflowJob.class, "junit-peer-site-config");
     // sandbox=false: we are exercising peer-library class visibility from the pipeline, not the

--- a/test/integration-junit/java/com/mkobit/libraryexample/IntegrationTest.java
+++ b/test/integration-junit/java/com/mkobit/libraryexample/IntegrationTest.java
@@ -73,8 +73,7 @@ class IntegrationTest {
   @Test
   void siteRegionStepFromPeerLibraryReturnsExpectedRegion(JenkinsRule rule) throws Exception {
     var job = rule.createProject(WorkflowJob.class, "junit-peer-site-region");
-    job.setDefinition(
-        new CpsFlowDefinition("echo 'Region: ' + siteRegion('us-east')", true));
+    job.setDefinition(new CpsFlowDefinition("echo 'Region: ' + siteRegion('us-east')", true));
 
     WorkflowRun run = rule.buildAndAssertSuccess(job);
     rule.assertLogContains("Region: us-east-1", run);
@@ -82,9 +81,6 @@ class IntegrationTest {
 
   @Test
   void baseAnnounceStepFromTransitivelyLoadedPeerLibraryWorks(JenkinsRule rule) throws Exception {
-    // Root declares only :config-lib. :config-lib in turn declares :base-lib as its own peer.
-    // The :base-lib source directory reaches Jenkins only through source-variant transitivity
-    // (sharedLibrarySourceElements extendsFrom sharedLibraryDependencies on the producer).
     var job = rule.createProject(WorkflowJob.class, "junit-transitive-peer");
     job.setDefinition(new CpsFlowDefinition("baseAnnounce('hello from root')", true));
 
@@ -95,9 +91,8 @@ class IntegrationTest {
   @Test
   void siteConfigClassFromPeerLibrarySrcAccessibleFromPipeline(JenkinsRule rule) throws Exception {
     var job = rule.createProject(WorkflowJob.class, "junit-peer-site-config");
-    // sandbox=false: we are exercising peer-library class visibility from the pipeline, not the
-    // script-security whitelist. Static methods on user-defined library classes are not on the
-    // default sandbox whitelist and would otherwise be rejected before the call reaches the class.
+    // sandbox=false: static methods on user-defined library classes are not on the default
+    // whitelist.
     job.setDefinition(
         new CpsFlowDefinition(
             "import com.mkobit.libraryexample.config.SiteConfig\n"

--- a/test/integration-junit/java/com/mkobit/libraryexample/IntegrationTest.java
+++ b/test/integration-junit/java/com/mkobit/libraryexample/IntegrationTest.java
@@ -71,6 +71,32 @@ class IntegrationTest {
   }
 
   @Test
+  void siteRegionStepFromPeerLibraryReturnsExpectedRegion(JenkinsRule rule) throws Exception {
+    var job = rule.createProject(WorkflowJob.class, "junit-peer-site-region");
+    job.setDefinition(
+        new CpsFlowDefinition("echo 'Region: ' + siteRegion('us-east')", true));
+
+    WorkflowRun run = rule.buildAndAssertSuccess(job);
+    rule.assertLogContains("Region: us-east-1", run);
+  }
+
+  @Test
+  void siteConfigClassFromPeerLibrarySrcAccessibleFromPipeline(JenkinsRule rule) throws Exception {
+    var job = rule.createProject(WorkflowJob.class, "junit-peer-site-config");
+    // sandbox=false: we are exercising peer-library class visibility from the pipeline, not the
+    // script-security whitelist. Static methods on user-defined library classes are not on the
+    // default sandbox whitelist and would otherwise be rejected before the call reaches the class.
+    job.setDefinition(
+        new CpsFlowDefinition(
+            "import com.mkobit.libraryexample.config.SiteConfig\n"
+                + "echo 'Region: ' + SiteConfig.region('eu-west')",
+            false));
+
+    WorkflowRun run = rule.buildAndAssertSuccess(job);
+    rule.assertLogContains("Region: eu-west-1", run);
+  }
+
+  @Test
   void lockStepFromPluginRunsSuccessfully(JenkinsRule rule) throws Exception {
     var job = rule.createProject(WorkflowJob.class, "junit-lock-step");
     job.setDefinition(


### PR DESCRIPTION
## Summary

- Adds `:config-lib` subproject as a peer shared library consumed by the root project via `sharedLibrary { dependencies { sharedLibrary(project(\":config-lib\")) } }`
- Adds `:base-lib` subproject as a peer of `:config-lib`; reaches the root project only through source-variant transitivity (`sharedLibrarySourceElements extendsFrom sharedLibraryDependencies`)
- Adds integration tests exercising:
  - `siteRegion()` step from `:config-lib` (`siteRegionStepFromPeerLibraryReturnsExpectedRegion`)
  - `baseAnnounce()` step from transitively loaded `:base-lib` (`baseAnnounceStepFromTransitivelyLoadedPeerLibraryWorks`)
  - `SiteConfig.region()` static method from `:config-lib` src, called from a pipeline without sandbox (`siteConfigClassFromPeerLibrarySrcAccessibleFromPipeline`)
- Depends on plugin PR #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)