### PR TITLE
infra: pin dependabot labels to project label set

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "enhancement"
     cooldown:
       # Gradle wrapper and test-framework bumps can land quickly; Jenkins plugin
       # dependencies managed by the BOM are in the ignore list below.
@@ -30,6 +32,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "infra"
     cooldown:
       default-days: 30
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "enhancement"
+      - "dependency-management"
     cooldown:
       # Gradle wrapper and test-framework bumps can land quickly; Jenkins plugin
       # dependencies managed by the BOM are in the ignore list below.


### PR DESCRIPTION
Use `enhancement` for Gradle updates and `infra` for GitHub Actions updates so Dependabot does not recreate the labels that were removed from the project.