### PR TITLE
infra: move composite build to standalone workflow-dispatch workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,6 @@ on:
       - 'LICENSE.txt'
       - '.gitignore'
   workflow_dispatch:
-    inputs:
-      plugin-ref:
-        description: "Plugin branch/tag for composite build job (default: main)"
-        default: main
 
 permissions: {}
 
@@ -42,30 +38,4 @@ jobs:
           distribution: temurin
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
       - name: Build
-        run: ./gradlew build --continue
-
-  build-composite:
-    name: Build (composite — plugin ${{ inputs.plugin-ref || 'main' }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    env:
-      DEVELOCITY_PUBLISH: "1"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          path: example
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          repository: mkobit/jenkins-pipeline-shared-libraries-gradle-plugin
-          ref: ${{ inputs.plugin-ref || 'main' }}
-          path: jenkins-pipeline-shared-libraries-gradle-plugin
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
-        with:
-          java-version: 21
-          distribution: temurin
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
-      - name: Build
-        working-directory: example
         run: ./gradlew build --continue

--- a/.github/workflows/composite.yml
+++ b/.github/workflows/composite.yml
@@ -1,0 +1,41 @@
+name: Composite build
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin-ref:
+        description: "Plugin repo branch/tag/SHA (default: main)"
+        default: main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (composite — plugin ${{ inputs.plugin-ref }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      DEVELOCITY_PUBLISH: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          path: example
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: mkobit/jenkins-pipeline-shared-libraries-gradle-plugin
+          ref: ${{ inputs.plugin-ref }}
+          path: jenkins-pipeline-shared-libraries-gradle-plugin
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+      - name: Build
+        working-directory: example
+        run: ./gradlew --include-build ../jenkins-pipeline-shared-libraries-gradle-plugin build --continue

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,4 @@
 pluginManagement {
-  if (file("../jenkins-pipeline-shared-libraries-gradle-plugin/settings.gradle.kts").exists()) {
-    includeBuild("../jenkins-pipeline-shared-libraries-gradle-plugin")
-  }
   repositories {
     gradlePluginPortal()
   }


### PR DESCRIPTION
## Summary

- Removes the filesystem-sniffing `includeBuild` from `settings.gradle.kts` — the regular build now resolves the plugin from Gradle Plugin Portal only
- Removes the `build-composite` job and `plugin-ref` input from `build.yml`, decoupling regular CI from the plugin repo
- Adds `composite.yml` — `workflow_dispatch` only, accepts a `plugin-ref` input (branch/tag/SHA, default `main`), and passes `--include-build` explicitly on the Gradle command line

To run: Actions → Composite build → Run workflow, pick the example branch in the branch dropdown, enter a plugin ref. Any example branch against any plugin branch.

Relates to https://github.com/mkobit/jenkins-pipeline-shared-library-example/issues/29

🤖 Generated with [Claude Code](https://claude.com/claude-code)