### PR TITLE
chore: Update dependabot label for gradle to infra

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "dependency-management"
+      - "infra"
     cooldown:
       # Gradle wrapper and test-framework bumps can land quickly; Jenkins plugin
       # dependencies managed by the BOM are in the ignore list below.


### PR DESCRIPTION
Changed the label for gradle package-ecosystem in `.github/dependabot.yml` from `dependency-management` to `infra` to match infrastructure label requirements.

---
*PR created automatically by Jules for task [133092276710003777](https://jules.google.com/task/133092276710003777) started by @mkobit*