### PR TITLE
chore(deps): group jetbrains dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,10 @@ updates:
       spock:
         patterns:
           - "org.spockframework:*"
+      jetbrains:
+        patterns:
+          - "org.jetbrains:*"
+          - "org.jetbrains.*:*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Update dependabot jvm gradle groups. All org.jetbrains should be grouped under jetbrains group.

---
*PR created automatically by Jules for task [14158721615839176344](https://jules.google.com/task/14158721615839176344) started by @mkobit*