### PR TITLE
chore: Group all Kotest dependencies in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
       kotest:
         patterns:
           - "io.kotest:*"
+          - "io.kotest.*:*"
       junit:
         patterns:
           - "org.junit.*:*"


### PR DESCRIPTION
This PR updates the `.github/dependabot.yml` configuration to group all Kotest dependencies together. It adds the `"io.kotest.*:*"` pattern to the existing `kotest` group, ensuring that sub-groups of `io.kotest` are also included in a single Dependabot update pull request, similarly to how JetBrains dependencies are handled.

---
*PR created automatically by Jules for task [771235820475731751](https://jules.google.com/task/771235820475731751) started by @mkobit*