### PR TITLE
chore: remove setScriptRoots from test initialization

### DIFF
--- a/test/unit/java/com/mkobit/libraryexample/PipelineTest.java
+++ b/test/unit/java/com/mkobit/libraryexample/PipelineTest.java
@@ -26,7 +26,7 @@ abstract class PipelineTest {
   @BeforeEach
   void initPipeline() throws Exception {
     base = new DeclarativePipelineTest() {};
-    base.setScriptRoots(new String[] {".", "vars"});
+
     base.setUp();
     base.getHelper()
         .registerAllowedMethod(


### PR DESCRIPTION
Removed the `setScriptRoots` method call, specifically mentioning the configuration `new String[]{"."}`, as requested because it is unnecessary for the project setup. Spotless was run.

---
*PR created automatically by Jules for task [4671704561366427963](https://jules.google.com/task/4671704561366427963) started by @mkobit*