### PR TITLE
docs: add groovydoc to all shared library code

### DIFF
--- a/src/com/mkobit/libraryexample/AnsiColorScriptStepsLogger.groovy
+++ b/src/com/mkobit/libraryexample/AnsiColorScriptStepsLogger.groovy
@@ -2,13 +2,20 @@ package com.mkobit.libraryexample
 
 import com.cloudbees.groovy.cps.NonCPS
 
-// Emits ANSI-colored output. Requires the AnsiColor Jenkins plugin to render colors in the log.
+/**
+ * Emits ANSI-colored output. Requires the AnsiColor Jenkins plugin to render colors in the log.
+ */
 class AnsiColorScriptStepsLogger implements PipelineLogger, Serializable {
 
     private final String tag
     private transient Object script
     private final int logLevel
 
+    /**
+     * Constructs a new ANSI color logger.
+     * @param script the pipeline script context
+     * @param tag a tag to prefix log messages with
+     */
     AnsiColorScriptStepsLogger(Object script, String tag) {
         this.script = Objects.requireNonNull(script)
         this.tag = Objects.requireNonNull(tag)
@@ -52,9 +59,16 @@ class AnsiColorScriptStepsLogger implements PipelineLogger, Serializable {
         }
     }
 
-    // padRight is CPS-unsafe (GDK collection method).
-    // ESC (0x1B) is built at runtime rather than as a string literal because
-    // GrEclipse (Spotless groovy formatter) crashes on raw control bytes in source.
+    /**
+     * Formats a log message with ANSI colors.
+     * padRight is CPS-unsafe (GDK collection method).
+     * ESC (0x1B) is built at runtime rather than as a string literal because
+     * GrEclipse (Spotless groovy formatter) crashes on raw control bytes in source.
+     * @param colorCode the ANSI color code
+     * @param level the log level string
+     * @param message the message
+     * @return the ANSI-colored log line
+     */
     @NonCPS
     private String ansi(String colorCode, String level, String message) {
         def esc = new String([27] as char[])

--- a/src/com/mkobit/libraryexample/BasicScriptStepsLogger.groovy
+++ b/src/com/mkobit/libraryexample/BasicScriptStepsLogger.groovy
@@ -2,12 +2,20 @@ package com.mkobit.libraryexample
 
 import com.cloudbees.groovy.cps.NonCPS
 
+/**
+ * A simple logger implementation that outputs messages using the standard Jenkins {@code echo} step.
+ */
 class BasicScriptStepsLogger implements PipelineLogger, Serializable {
 
     private final String tag
     private transient Object script
     private final int logLevel
 
+    /**
+     * Constructs a new basic logger.
+     * @param script the pipeline script context
+     * @param tag a tag to prefix log messages with
+     */
     BasicScriptStepsLogger(Object script, String tag) {
         this.script = Objects.requireNonNull(script)
         this.tag = Objects.requireNonNull(tag)
@@ -51,7 +59,13 @@ class BasicScriptStepsLogger implements PipelineLogger, Serializable {
         }
     }
 
-    // padRight is CPS-unsafe (GDK collection method).
+    /**
+     * Formats a log message.
+     * padRight is CPS-unsafe (GDK collection method).
+     * @param level the log level string
+     * @param message the message
+     * @return the formatted log line
+     */
     @NonCPS
     private String format(String level, String message) {
         "[${level.padRight(5)} ${tag}] ${message}"

--- a/src/com/mkobit/libraryexample/BranchPolicy.groovy
+++ b/src/com/mkobit/libraryexample/BranchPolicy.groovy
@@ -3,30 +3,49 @@ package com.mkobit.libraryexample
 import com.cloudbees.groovy.cps.NonCPS
 import groovy.transform.CompileStatic
 
+/**
+ * Classifies a branch name into an environment.
+ */
 @CompileStatic
 class BranchPolicy implements Serializable {
 
     private final String branchName
 
+    /**
+     * Constructs a new branch policy.
+     * @param branchName the name of the branch
+     */
     BranchPolicy(final String branchName) {
         this.branchName = Objects.requireNonNull(branchName)
     }
 
+    /**
+     * @return whether the branch is the main branch
+     */
     @NonCPS
     boolean isMain() {
         branchName == 'main' || branchName == 'master'
     }
 
+    /**
+     * @return whether the branch is a release branch
+     */
     @NonCPS
     boolean isRelease() {
         branchName.startsWith('release/')
     }
 
+    /**
+     * @return whether the branch is a pull request branch
+     */
     @NonCPS
     boolean isPullRequest() {
         branchName.startsWith('PR-')
     }
 
+    /**
+     * @return the environment classification for the branch
+     */
     @NonCPS
     String getEnvironment() {
         if (main) {

--- a/src/com/mkobit/libraryexample/BuildContext.groovy
+++ b/src/com/mkobit/libraryexample/BuildContext.groovy
@@ -2,7 +2,10 @@ package com.mkobit.libraryexample
 
 import com.cloudbees.groovy.cps.NonCPS
 
-// Reads env eagerly so no script reference is kept after construction.
+/**
+ * Context object containing build metadata.
+ * Reads env eagerly so no script reference is kept after construction.
+ */
 class BuildContext implements Serializable {
 
     final String jobName
@@ -10,6 +13,10 @@ class BuildContext implements Serializable {
     final String branch
     final String commitSha
 
+    /**
+     * Constructs a build context.
+     * @param script the pipeline script to read env from
+     */
     BuildContext(final Object script) {
         this.jobName     = script.env.JOB_NAME      ?: 'unknown'
         this.buildNumber = (script.env.BUILD_NUMBER  ?: '0').toInteger()
@@ -17,7 +24,11 @@ class BuildContext implements Serializable {
         this.commitSha   = script.env.GIT_COMMIT     ?: 'unknown'
     }
 
-    // Map literal construction is CPS-unsafe.
+    /**
+     * Returns the context as a map.
+     * Map literal construction is CPS-unsafe.
+     * @return the build context map
+     */
     @NonCPS
     Map<String, Object> toMap() {
         [job: jobName, build: buildNumber, branch: branch, commit: commitSha]

--- a/src/com/mkobit/libraryexample/ConventionalCommit.groovy
+++ b/src/com/mkobit/libraryexample/ConventionalCommit.groovy
@@ -2,6 +2,9 @@ package com.mkobit.libraryexample
 
 import com.cloudbees.groovy.cps.NonCPS
 
+/**
+ * Parses and classifies a Conventional Commit message.
+ */
 class ConventionalCommit implements Serializable {
 
     final String type
@@ -14,6 +17,11 @@ class ConventionalCommit implements Serializable {
         this.description = description
     }
 
+    /**
+     * Parses a commit message string.
+     * @param message the message to parse
+     * @return the parsed Conventional Commit, or null if it does not match
+     */
     @NonCPS
     static ConventionalCommit parse(String message) {
         def m = (message =~ /^(\w+)(?:\([^)]*\))?(!)?:\s+(.+)$/)
@@ -23,6 +31,11 @@ class ConventionalCommit implements Serializable {
         new ConventionalCommit(m[0][1], m[0][2] == '!', m[0][3])
     }
 
+    /**
+     * Finds the highest version bump type from a list of commit subjects.
+     * @param subjects the list of commit subjects
+     * @return the highest bump type ('major', 'minor', or 'patch')
+     */
     @NonCPS
     static String highestBump(List<String> subjects) {
         def result = null
@@ -44,6 +57,9 @@ class ConventionalCommit implements Serializable {
         result
     }
 
+    /**
+     * @return the bump type for this commit ('major', 'minor', or 'patch')
+     */
     @NonCPS
     String getBumpType() {
         if (breaking) {

--- a/src/com/mkobit/libraryexample/PipelineLogger.groovy
+++ b/src/com/mkobit/libraryexample/PipelineLogger.groovy
@@ -1,6 +1,9 @@
 package com.mkobit.libraryexample
 
-// Numeric log levels for PIPELINE_LOG_LEVEL env var: 1=DEBUG, 2=INFO (default), 3=WARN, 4=ERROR.
+/**
+ * Interface for pipeline logging.
+ * Numeric log levels for {@code PIPELINE_LOG_LEVEL} env var: 1=DEBUG, 2=INFO (default), 3=WARN, 4=ERROR.
+ */
 interface PipelineLogger extends Serializable {
 
     int DEBUG = 1
@@ -8,11 +11,27 @@ interface PipelineLogger extends Serializable {
     int WARN  = 3
     int ERROR = 4
 
+    /**
+     * Logs a debug message.
+     * @param message the message to log
+     */
     void debug(String message)
 
+    /**
+     * Logs an info message.
+     * @param message the message to log
+     */
     void info(String message)
 
+    /**
+     * Logs a warning message.
+     * @param message the message to log
+     */
     void warn(String message)
 
+    /**
+     * Logs an error message.
+     * @param message the message to log
+     */
     void error(String message)
 }

--- a/src/com/mkobit/libraryexample/SemVer.groovy
+++ b/src/com/mkobit/libraryexample/SemVer.groovy
@@ -2,12 +2,21 @@ package com.mkobit.libraryexample
 
 import com.cloudbees.groovy.cps.NonCPS
 
+/**
+ * Represents a Semantic Version.
+ */
 class SemVer implements Serializable, Comparable<SemVer> {
 
     final int major
     final int minor
     final int patch
 
+    /**
+     * Constructs a Semantic Version.
+     * @param major the major version component
+     * @param minor the minor version component
+     * @param patch the patch version component
+     */
     SemVer(int major, int minor, int patch) {
         if (major < 0 || minor < 0 || patch < 0) {
             throw new IllegalArgumentException("SemVer components must be non-negative: ${major}.${minor}.${patch}")
@@ -17,6 +26,11 @@ class SemVer implements Serializable, Comparable<SemVer> {
         this.patch = patch
     }
 
+    /**
+     * Parses a string into a Semantic Version.
+     * @param version the version string to parse
+     * @return the parsed Semantic Version
+     */
     @NonCPS
     static SemVer parse(String version) {
         def m = (version =~ /^v?(\d+)\.(\d+)\.(\d+)$/)
@@ -26,16 +40,28 @@ class SemVer implements Serializable, Comparable<SemVer> {
         new SemVer(m[0][1] as int, m[0][2] as int, m[0][3] as int)
     }
 
+    /**
+     * Bumps the major version.
+     * @return a new Semantic Version with the bumped major version
+     */
     @NonCPS
     SemVer bumpMajor() {
         new SemVer(major + 1, 0, 0)
     }
 
+    /**
+     * Bumps the minor version.
+     * @return a new Semantic Version with the bumped minor version
+     */
     @NonCPS
     SemVer bumpMinor() {
         new SemVer(major, minor + 1, 0)
     }
 
+    /**
+     * Bumps the patch version.
+     * @return a new Semantic Version with the bumped patch version
+     */
     @NonCPS
     SemVer bumpPatch() {
         new SemVer(major, minor, patch + 1)

--- a/vars/captureBuildInfo.groovy
+++ b/vars/captureBuildInfo.groovy
@@ -2,8 +2,12 @@ import com.mkobit.libraryexample.BasicScriptStepsLogger
 import com.mkobit.libraryexample.BuildContext
 import com.mkobit.libraryexample.PipelineLogger
 
-// Accepts an optional logger to demonstrate dependency injection.
-// Default: BasicScriptStepsLogger reading PIPELINE_LOG_LEVEL from env.
+/**
+ * Logs job metadata.
+ * Accepts an optional logger to demonstrate dependency injection.
+ * Default: BasicScriptStepsLogger reading PIPELINE_LOG_LEVEL from env.
+ * @param log an optional custom logger
+ */
 def call(PipelineLogger log = null) {
     def effectiveLog = log ?: new BasicScriptStepsLogger(this, 'captureBuildInfo')
     def ctx = new BuildContext(this)

--- a/vars/eventually.groovy
+++ b/vars/eventually.groovy
@@ -1,7 +1,11 @@
 import com.mkobit.libraryexample.BasicScriptStepsLogger
 
-// Polls a boolean condition with exponential backoff; unlike retry, this does not require exceptions.
-// Accepts: maxAttempts (int), initialWaitSeconds (int), backoffMultiplier (int).
+/**
+ * Polls a boolean condition with exponential backoff; unlike retry, this does not require exceptions.
+ * Accepts: maxAttempts (int), initialWaitSeconds (int), backoffMultiplier (int).
+ * @param opts options map
+ * @param condition the condition to evaluate
+ */
 def call(Map opts = [:], Closure condition) {
     def log = new BasicScriptStepsLogger(this, 'eventually')
     def maxAttempts = opts.maxAttempts != null ? opts.maxAttempts : 5

--- a/vars/nextReleaseVersion.groovy
+++ b/vars/nextReleaseVersion.groovy
@@ -1,6 +1,11 @@
 import com.mkobit.libraryexample.ConventionalCommit
 import com.mkobit.libraryexample.SemVer
 
+/**
+ * Computes next version from git tags and conventional commits.
+ * @param fallback the fallback version to use if no tags exist
+ * @return the next version string
+ */
 def call(String fallback = 'v0.0.0') {
     def tag = sh(script: 'git tag --list "v*.*.*" --sort=-v:refname | head -1', returnStdout: true).trim()
     def base = SemVer.parse(tag ?: fallback)

--- a/vars/notifyBuild.groovy
+++ b/vars/notifyBuild.groovy
@@ -1,6 +1,10 @@
 import com.mkobit.libraryexample.BasicScriptStepsLogger
 import com.mkobit.libraryexample.BuildContext
 
+/**
+ * Emits a build notification message with job metadata.
+ * @param status the build status to notify
+ */
 def call(String status) {
     def log = new BasicScriptStepsLogger(this, 'notifyBuild')
     def ctx = new BuildContext(this)

--- a/vars/requireConventionalPrTitle.groovy
+++ b/vars/requireConventionalPrTitle.groovy
@@ -1,5 +1,8 @@
 import com.mkobit.libraryexample.ConventionalCommit
 
+/**
+ * Fails the build if the PR title is not a conventional commit.
+ */
 def call() {
     if (!env.CHANGE_ID) {
         return

--- a/vars/requireEnv.groovy
+++ b/vars/requireEnv.groovy
@@ -1,4 +1,7 @@
-/** Fails the build if any of the named environment variables are absent. */
+/**
+ * Fails the build if any of the named environment variables are absent.
+ * @param names the names of the environment variables to check
+ */
 def call(String... names) {
     def missing = []
     for (def name in names) {

--- a/vars/tagBuild.groovy
+++ b/vars/tagBuild.groovy
@@ -1,3 +1,7 @@
+/**
+ * Sets the build's display name and description.
+ * @param label the label to set
+ */
 def call(String label) {
     currentBuild.displayName = "#${currentBuild.number} ${label}"
     currentBuild.description = label

--- a/vars/withParallelMatrix.groovy
+++ b/vars/withParallelMatrix.groovy
@@ -1,6 +1,11 @@
 import com.cloudbees.groovy.cps.NonCPS
 import com.mkobit.libraryexample.BasicScriptStepsLogger
 
+/**
+ * Runs a closure for every combination of axis values in parallel.
+ * @param axes a map of axis names to list of values
+ * @param body the closure to execute for each combination
+ */
 def call(Map axes, Closure body) {
     def log = new BasicScriptStepsLogger(this, 'withParallelMatrix')
     def combinations = cartesianProduct(axes)


### PR DESCRIPTION
Added formal GroovyDoc to all shared library code in `src/` and `vars/` directories to improve documentation.

This covers:
- `PipelineLogger.groovy`
- `BasicScriptStepsLogger.groovy`
- `AnsiColorScriptStepsLogger.groovy`
- `BranchPolicy.groovy`
- `SemVer.groovy`
- `ConventionalCommit.groovy`
- `BuildContext.groovy`
- `notifyBuild.groovy`
- `withParallelMatrix.groovy`
- `tagBuild.groovy`
- `requireEnv.groovy`
- `captureBuildInfo.groovy`
- `eventually.groovy`
- `nextReleaseVersion.groovy`
- `requireConventionalPrTitle.groovy`

---
*PR created automatically by Jules for task [15905388738848885204](https://jules.google.com/task/15905388738848885204) started by @mkobit*