### PR TITLE
chore: remove openrewrite and group build-infra dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,11 @@ updates:
       # This project owns the shared-library plugin; pin updates manually.
       - dependency-name: "com.mkobit.jenkins.pipelines.shared-library"
     groups:
+      build-infra:
+        patterns:
+          - "com.gradle.develocity"
+          - "com.diffplug.spotless"
+          - "org.gradle.toolchains.foojay-resolver-convention"
       kotest:
         patterns:
           - "io.kotest:*"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ import org.gradle.api.tasks.testing.logging.TestStackTraceFilter
 
 plugins {
   alias(libs.plugins.shared.library)
-  alias(libs.plugins.openrewrite)
   alias(libs.plugins.spotless)
   codenarc
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ jenkins-pipeline-unit = "1.30"
 junit-jupiter = "6.1.0"
 kotest = "6.1.11"
 kotlin = "2.3.21"
-openrewrite = "7.32.2"
 spock = "2.4-groovy-2.5"
 spotless = "8.6.0"
 
@@ -29,6 +28,5 @@ spock-junit4 = { module = "org.spockframework:spock-junit4", version.ref = "spoc
 [plugins]
 foojay = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-openrewrite = { id = "org.openrewrite.rewrite", version.ref = "openrewrite" }
 shared-library = { id = "com.mkobit.jenkins.pipelines.shared-library", version = "0.12.1" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
## Summary
* Removed openrewrite entirely from the repository, including `libs.versions.toml` and `build.gradle.kts`.
* Added `build-infra` grouping to `.github/dependabot.yml` for `com.gradle.develocity`, `com.diffplug.spotless`, and `org.gradle.toolchains.foojay-resolver-convention` to land as one PR.

---
*PR created automatically by Jules for task [12358030868657812130](https://jules.google.com/task/12358030868657812130) started by @mkobit*