### PR TITLE
deps: bump com.mkobit.jenkins.pipelines.shared-library to 0.12.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,5 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.workers.max=2
 org.gradle.caching=true
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
 org.gradle.warning.mode=fail

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,5 +30,5 @@ spock-junit4 = { module = "org.spockframework:spock-junit4", version.ref = "spoc
 foojay = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojay" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 openrewrite = { id = "org.openrewrite.rewrite", version.ref = "openrewrite" }
-shared-library = { id = "com.mkobit.jenkins.pipelines.shared-library", version = "0.12.0" }
+shared-library = { id = "com.mkobit.jenkins.pipelines.shared-library", version = "0.12.1" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
## Summary
- Bumped `com.mkobit.jenkins.pipelines.shared-library` Gradle plugin from 0.12.0 to 0.12.1 (see [0.12.1 release notes](https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin/releases/tag/v0.12.1)).
- Restored `org.gradle.configuration-cache=true` which was previously disabled due to a regression in 0.12.0 (see [fix PR #269](https://github.com/mkobit/jenkins-pipeline-shared-libraries-gradle-plugin/pull/269)).

---
*PR created automatically by Jules for task [17745444740624097035](https://jules.google.com/task/17745444740624097035) started by @mkobit*